### PR TITLE
beast: Fix bug with repeated 1a values

### DIFF
--- a/beast/frame.go
+++ b/beast/frame.go
@@ -51,8 +51,8 @@ func (f *Frame) UnmarshalBinary(data []byte) error {
 	}
 
 	for i := 0; i < len(data); i++ {
-		if i > 0 && data[i-1] == 0x1a && data[i] == 0x1a {
-			continue
+		if data[i] == 0x1a && (i+1) < len(data) && data[i+1] == 0x1a {
+			i++
 		}
 
 		f.data.WriteByte(data[i])

--- a/beast/frame_test.go
+++ b/beast/frame_test.go
@@ -61,6 +61,7 @@ func TestUnmarshalError(t *testing.T) {
 	t.Run("BadLength1", testUnmarshalBadLength1)
 	t.Run("BadLength2", testUnmarshalBadLength2)
 	t.Run("BadLength3", testUnmarshalBadLength3)
+	t.Run("BadEscape", testUnmarshalBadEscape)
 	t.Run("BadType", testUnmarshalBadType)
 	t.Run("NoType", testUnmarshalNoType)
 }
@@ -79,6 +80,10 @@ func testUnmarshalBadLength2(t *testing.T) {
 
 func testUnmarshalBadLength3(t *testing.T) {
 	testUnmarshalError(t, "1a33ffffffffffffffffffffffffffffffffffffffffffffff", "expected 23 bytes, received 25")
+}
+
+func testUnmarshalBadEscape(t *testing.T) {
+	testUnmarshalError(t, "1a31ffffffffffffffffffffffffff1a", "expected 11 bytes, received 16")
 }
 
 func testUnmarshalBadType(t *testing.T) {
@@ -227,12 +232,12 @@ func testUnmarshalMarshal(t *testing.T) {
 }
 
 func testUnmarshalADSB(t *testing.T) {
-	msg, err := hex.DecodeString("1a321a1af933baf325c45da99adad95ff6")
+	msg, err := hex.DecodeString("1a321a1af933baf325c45da99adad91a1a1a1a")
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
-	data, err := hex.DecodeString("5da99adad95ff6")
+	data, err := hex.DecodeString("5da99adad91a1a")
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}


### PR DESCRIPTION
Repeated 1a1a (1a1a1a1a) would get shortened to a single 1a value
instead of just removing the appropriate escapes. Reworked the logic to
skip the first 1a, write the second, then evaluate the next value.