### PR TITLE
Updates to CI, rename master to main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: GolangCI Lint
+name: Lint
 on: [pull_request]
 
 env:
@@ -7,7 +7,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: Lint
+    name: GolangCI-Lint
     steps:
       - name: Setup Go
         uses: actions/setup-go@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  GO111MODULE: on
+  GOPROXY: https://proxy.golang.org
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Release Updates
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15.0'
+      - name: Go Get
+        run: go get kreklow.us/go/go-adsb@${GITHUB_REF#'refs/tags/'}

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,3 @@ jobs:
       stage: validate
       script: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
       after_success: bash <(curl -s https://codecov.io/bash)
-    - name: "Refresh GoDoc and Go Report Card"
-      stage: refresh
-      if: branch = master AND type = push
-      language: shell
-      install: skip
-      script:
-        - curl -d "repo=kreklow.us/go/go-adsb" https://goreportcard.com/checks
-        - curl -d "path=kreklow.us/go/go-adsb" https://godoc.org/-/refresh

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![PkgGoDev](https://pkg.go.dev/badge/kreklow.us/go/go-adsb)](https://pkg.go.dev/kreklow.us/go/go-adsb)
 ![GitHub](https://img.shields.io/github/license/cjkreklow/go-adsb.svg)
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/cjkreklow/go-adsb.svg)
-[![Build Status](https://www.travis-ci.org/cjkreklow/go-adsb.svg?branch=master)](https://www.travis-ci.org/cjkreklow/go-adsb)
-[![codecov](https://codecov.io/gh/cjkreklow/go-adsb/branch/master/graph/badge.svg)](https://codecov.io/gh/cjkreklow/go-adsb)
+[![Build Status](https://www.travis-ci.org/cjkreklow/go-adsb.svg?branch=main)](https://www.travis-ci.org/cjkreklow/go-adsb)
+[![codecov](https://codecov.io/gh/cjkreklow/go-adsb/branch/main/graph/badge.svg)](https://codecov.io/gh/cjkreklow/go-adsb)
 [![Go Report Card](https://goreportcard.com/badge/kreklow.us/go/go-adsb)](https://goreportcard.com/report/kreklow.us/go/go-adsb)
 
 `go-adsb` is a Go Module which includes packages for working with ADS-B

--- a/README.md
+++ b/README.md
@@ -4,14 +4,12 @@
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/cjkreklow/go-adsb.svg)
 [![Build Status](https://www.travis-ci.org/cjkreklow/go-adsb.svg?branch=main)](https://www.travis-ci.org/cjkreklow/go-adsb)
 [![codecov](https://codecov.io/gh/cjkreklow/go-adsb/branch/main/graph/badge.svg)](https://codecov.io/gh/cjkreklow/go-adsb)
-[![Go Report Card](https://goreportcard.com/badge/kreklow.us/go/go-adsb)](https://goreportcard.com/report/kreklow.us/go/go-adsb)
 
 `go-adsb` is a Go Module which includes packages for working with ADS-B
 aircraft tracking data.
 
-
 # Usage
-See the individual package GoDoc pages for import paths and usage
+See the individual package documentation pages for import paths and usage
 information.
 
 # About

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 coverage:
   precision: 2
   round: down
-  range: "80...95"
+  range: "75...90"
   status:
     project:
       default: false
@@ -10,10 +10,10 @@ coverage:
         paths:
           - adsb
       beast:
-        target: 95%
+        target: 90%
         paths:
           - beast
     patch:
       default:
         target: auto
-        threshold: 5%
+        threshold: 10%


### PR DESCRIPTION
- Remove refresh of Go Report Card and GoDoc from Travis
- Add pull from Go proxy on tag push to refresh pkg.go.dev
- Rename master branch to main