### PR TITLE
Feature updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+on: [push]
+
+env:
+  GO111MODULE: on
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '~1.15.0', '~1.14.0', '~1.13.0' ]
+    name: Go ${{ matrix.go }}
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run Tests
+        run: go test -v -race ./...
+  codecov:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Codecov
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~1.15.0'
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run Tests
+        run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.txt

--- a/adsb/message.go
+++ b/adsb/message.go
@@ -74,7 +74,7 @@ func (m *Message) validateRaw() error {
 	}
 
 	switch df {
-	case 0, 4, 5, 11, 16, 17, 18, 20, 21:
+	case 0, 4, 5, 11, 16, 17, 18, 20, 21, 24:
 		return nil
 	default:
 		return newErrorf(ErrUnsupported, "downlink format %d", df)

--- a/adsb/message_test.go
+++ b/adsb/message_test.go
@@ -58,7 +58,7 @@ func testMsgEmptyRaw(t *testing.T) {
 }
 
 func testMsgUnsupported(t *testing.T) {
-	raw, err := hex.DecodeString("ff0000000000ff000000000000ff")
+	raw, err := hex.DecodeString("980000000000ff000000000000ff")
 	if err != nil {
 		t.Fatal("received unexpected error", err)
 	}
@@ -75,7 +75,7 @@ func testMsgUnsupported(t *testing.T) {
 		t.Fatal("received nil, expected error")
 	}
 
-	if err.Error() != "downlink format 24: format unsupported" {
+	if err.Error() != "downlink format 19: format unsupported" {
 		t.Error("received unexpected error", err)
 	}
 
@@ -373,6 +373,7 @@ func TestDecode(t *testing.T) {
 	t.Run("DF17 Identity", testDF17Ident)
 	t.Run("DF20", testDF20)
 	t.Run("DF21", testDF21)
+	t.Run("DF24", testDF24)
 }
 
 // TestDecodeErrors runs test cases for message decoding errors.
@@ -550,6 +551,30 @@ func testDF21(t *testing.T) {
 		ICAO: 0xa97db4,
 		Alt:  0,
 		Sqk:  []byte{6, 0, 1, 7},
+		Call: "",
+	}
+
+	testDecode(t, tc)
+}
+
+func testDF24(t *testing.T) {
+	tc := &testCase{
+		Msg: "c4576da66a68295e7d22ed5dd112",
+
+		DF: 24,
+		CA: -1,
+		FS: -1,
+		VS: -1,
+
+		TC:  -1,
+		SS:  -1,
+		Cat: "",
+
+		CPR: false,
+
+		ICAO: 0xab4531,
+		Alt:  0,
+		Sqk:  []byte{},
 		Call: "",
 	}
 

--- a/beast/frame.go
+++ b/beast/frame.go
@@ -106,7 +106,7 @@ func (f Frame) Bytes() []byte {
 	return f.data.Bytes()
 }
 
-// MarshalADSB returns the ADS-B or Mode-AC data in the Frame.
+// MarshalADSB returns the ADS-B data in the Frame.
 //
 // The returned slice remains valid until the next call to
 // UnmarshalBinary. Modifying the returned slice directly may impact
@@ -116,7 +116,28 @@ func (f Frame) MarshalADSB() ([]byte, error) {
 		return nil, ErrNoData
 	}
 
-	return f.data.Bytes()[9:], nil
+	b := f.data.Bytes()
+
+	if !(b[0] == 0x1a && (b[1] == 0x32 || b[1] == 0x33)) {
+		return nil, ErrNoData
+	}
+
+	return b[9:], nil
+}
+
+// ModeAC returns the Mode AC data in the Frame.
+func (f Frame) ModeAC() ([]byte, error) {
+	if f.data.Len() < 10 {
+		return nil, ErrNoData
+	}
+
+	b := f.data.Bytes()
+
+	if !(b[0] == 0x1a && b[1] == 0x31) {
+		return nil, ErrNoData
+	}
+
+	return append(make([]byte, 0, 2), b[9:11]...), nil
 }
 
 // Timestamp returns the MLAT timestamp as a time.Duration.


### PR DESCRIPTION
- Allow loading of DF24 to Message without an error.
- Add a separate ModeAC method to Frame, only return Mode S data in MarshalADSB.