### PR TITLE
Update Frame methods to pointer receivers

### DIFF
--- a/beast/frame.go
+++ b/beast/frame.go
@@ -102,7 +102,7 @@ func (f *Frame) MarshalBinary() ([]byte, error) {
 // The returned slice remains valid until the next call to
 // UnmarshalBinary. Modifying the returned slice directly may impact
 // future Frame method calls.
-func (f Frame) Bytes() []byte {
+func (f *Frame) Bytes() []byte {
 	return f.data.Bytes()
 }
 
@@ -111,7 +111,7 @@ func (f Frame) Bytes() []byte {
 // The returned slice remains valid until the next call to
 // UnmarshalBinary. Modifying the returned slice directly may impact
 // future Frame method calls.
-func (f Frame) MarshalADSB() ([]byte, error) {
+func (f *Frame) MarshalADSB() ([]byte, error) {
 	if f.data.Len() < 10 {
 		return nil, ErrNoData
 	}
@@ -126,7 +126,7 @@ func (f Frame) MarshalADSB() ([]byte, error) {
 }
 
 // ModeAC returns the Mode AC data in the Frame.
-func (f Frame) ModeAC() ([]byte, error) {
+func (f *Frame) ModeAC() ([]byte, error) {
 	if f.data.Len() < 10 {
 		return nil, ErrNoData
 	}
@@ -141,7 +141,7 @@ func (f Frame) ModeAC() ([]byte, error) {
 }
 
 // Timestamp returns the MLAT timestamp as a time.Duration.
-func (f Frame) Timestamp() (time.Duration, error) {
+func (f *Frame) Timestamp() (time.Duration, error) {
 	if f.data.Len() < 8 {
 		return time.Duration(0), ErrNoData
 	}
@@ -154,7 +154,7 @@ func (f Frame) Timestamp() (time.Duration, error) {
 }
 
 // Signal returns the signal level.
-func (f Frame) Signal() (uint8, error) {
+func (f *Frame) Signal() (uint8, error) {
 	if f.data.Len() < 9 {
 		return 0, ErrNoData
 	}

--- a/beast/internal/mock.go
+++ b/beast/internal/mock.go
@@ -20,7 +20,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-//nolint:golint,goerr113 // internal test package
+// Package internal contains mock objects for testing.
 package internal
 
 import (
@@ -28,6 +28,7 @@ import (
 	"errors"
 )
 
+// MockReader implements decoderReader.
 type MockReader struct {
 	Buf *bytes.Buffer
 
@@ -42,17 +43,19 @@ type MockReader struct {
 	UnreadErr  error
 }
 
+// Buffered returns the number of bytes in Buf.
 func (r *MockReader) Buffered() int {
 	return r.Buf.Len()
 }
 
+// Discard the specified number of bytes from Buf.
 func (r *MockReader) Discard(n int) (int, error) {
 	if n > r.DiscardCount {
 		if r.DiscardErr != nil {
 			return 0, r.DiscardErr
 		}
 
-		return 0, errors.New("unexpected error in Discard")
+		return 0, errors.New("unexpected error in Discard") //nolint:err113 // no error to wrap
 	}
 
 	r.DiscardCount -= n
@@ -60,13 +63,15 @@ func (r *MockReader) Discard(n int) (int, error) {
 	return n, nil
 }
 
+// Peek returns the specified number of bytes from Buf without
+// discarding.
 func (r *MockReader) Peek(n int) ([]byte, error) {
 	if n > r.PeekCount {
 		if r.PeekErr != nil {
 			return nil, r.PeekErr
 		}
 
-		return nil, errors.New("unexpected error in Peek")
+		return nil, errors.New("unexpected error in Peek") //nolint:err113 // no error to wrap
 	}
 
 	r.PeekCount -= n
@@ -74,13 +79,14 @@ func (r *MockReader) Peek(n int) ([]byte, error) {
 	return r.Buf.Next(n), nil
 }
 
+// ReadByte returns the next available byte from Buf.
 func (r *MockReader) ReadByte() (byte, error) {
 	if r.ReadCount == 0 {
 		if r.ReadErr != nil {
 			return 0, r.ReadErr
 		}
 
-		return 0, errors.New("unexpected error in ReadByte")
+		return 0, errors.New("unexpected error in ReadByte") //nolint:err113 // no error to wrap
 	}
 
 	r.ReadCount--
@@ -88,13 +94,14 @@ func (r *MockReader) ReadByte() (byte, error) {
 	return r.Buf.ReadByte()
 }
 
+// UnreadByte places the last read byte back into Buf.
 func (r *MockReader) UnreadByte() error {
 	if r.UnreadCount == 0 {
 		if r.UnreadErr != nil {
 			return r.UnreadErr
 		}
 
-		return errors.New("unexpected error in UnreadByte")
+		return errors.New("unexpected error in UnreadByte") //nolint:err113 // no error to wrap
 	}
 
 	r.UnreadCount--
@@ -102,10 +109,12 @@ func (r *MockReader) UnreadByte() error {
 	return nil
 }
 
+// MockFrame implements BinaryUnmarshaler.
 type MockFrame struct {
 	Buf bytes.Buffer
 }
 
+// UnmarshalBinary stores data into Buf.
 func (f *MockFrame) UnmarshalBinary(data []byte) error {
 	f.Buf.Write(data)
 


### PR DESCRIPTION
Frame should be referenced by pointer to avoid allocations.