### PR TITLE
adsb: decode ADS-B airborne velocity (TC19 / BDS 0,9)

### DIFF
--- a/adsb/velocity.go
+++ b/adsb/velocity.go
@@ -1,0 +1,199 @@
+// Copyright 2026 Collin Kreklow
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+// BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package adsb
+
+import (
+	"math"
+
+	"github.com/ccoveille/go-safecast/v2"
+	"kreklow.us/go/go-adsb/adsbtype"
+)
+
+// Velocity is a decoded ADS-B airborne velocity message (extended squitter
+// type code 19, BDS 0,9). The Subtype selects which horizontal quantity is
+// reported: subtypes 1 and 2 report ground speed and track; subtypes 3 and 4
+// report airspeed and heading. Subtypes 2 and 4 are the supersonic variants.
+//
+// Optional quantities are pointers: a nil pointer means the field carried the
+// register's "no data" sentinel and no value is reported.
+type Velocity struct {
+	Subtype uint8 // 1..4
+
+	// Ground-speed subtypes (1, 2).
+	GroundSpeed *float64 // knots
+	Track       *float64 // degrees clockwise from true north, 0..360
+
+	// Airspeed subtypes (3, 4).
+	Airspeed     *float64     // knots
+	AirspeedType adsbtype.AST // IAS or TAS; meaningful when Airspeed != nil
+	Heading      *float64     // degrees clockwise from magnetic north, 0..360
+
+	// Vertical rate — reported by all subtypes.
+	VerticalRate       *int         // feet/minute, positive up
+	VerticalRateSource adsbtype.VRS // baro or GNSS; meaningful when VerticalRate != nil
+
+	// GNSS minus barometric altitude difference.
+	GNSSBaroDiff *int // feet, signed (positive = GNSS above baro)
+
+	// Status / accuracy metadata (always present).
+	IntentChange  bool
+	IFRCapability bool
+	NACv          uint8 // 0..7, velocity accuracy category
+}
+
+// Velocity returns the decoded airborne velocity (extended squitter type
+// code 19, BDS 0,9). It returns an error wrapping ErrNotAvailable unless the
+// message is a DF17/DF18 extended squitter with type code 19 and a defined
+// subtype (1..4).
+func (m *Message) Velocity() (*Velocity, error) {
+	tc, err := m.raw.ESType()
+	if err != nil {
+		return nil, newError(err, "error retrieving velocity")
+	}
+
+	if tc != 19 {
+		return nil, newErrorf(ErrNotAvailable,
+			"error retrieving velocity from type %d", tc)
+	}
+
+	r := m.raw
+
+	v := &Velocity{
+		Subtype:       safecast.MustConvert[uint8](r.esbits(6, 8)),
+		IntentChange:  r.esbits(9, 9) == 1,
+		IFRCapability: r.esbits(10, 10) == 1,
+		NACv:          safecast.MustConvert[uint8](r.esbits(11, 13)),
+	}
+
+	switch v.Subtype {
+	case 1, 2:
+		decodeGroundSpeed(r, v)
+	case 3, 4:
+		decodeAirspeed(r, v)
+	default:
+		return nil, newErrorf(ErrNotAvailable,
+			"unsupported velocity subtype %d", v.Subtype)
+	}
+
+	decodeVerticalRate(r, v)
+	decodeGNSSBaroDiff(r, v)
+
+	return v, nil
+}
+
+// velScale returns the velocity resolution in knots per count: 1 for the
+// subsonic subtypes (1, 3) and 4 for the supersonic subtypes (2, 4).
+func velScale(subtype uint8) float64 {
+	if subtype == 2 || subtype == 4 {
+		return 4
+	}
+
+	return 1
+}
+
+// decodeGroundSpeed decodes the subtype 1/2 east-west and north-south
+// velocity components into ground speed and true-north track. A zero raw
+// component is the "no data" sentinel, leaving GroundSpeed and Track nil.
+func decodeGroundSpeed(r *RawMessage, v *Velocity) {
+	ew := r.esbits(15, 24)
+	ns := r.esbits(26, 35)
+
+	if ew == 0 || ns == 0 {
+		return
+	}
+
+	scale := velScale(v.Subtype)
+
+	vEW := (float64(ew) - 1) * scale
+	if r.esbits(14, 14) == 1 { // 1 = west
+		vEW = -vEW
+	}
+
+	vNS := (float64(ns) - 1) * scale
+	if r.esbits(25, 25) == 1 { // 1 = south
+		vNS = -vNS
+	}
+
+	gs := math.Hypot(vEW, vNS)
+
+	track := math.Atan2(vEW, vNS) * 180 / math.Pi
+	if track < 0 {
+		track += 360
+	}
+
+	v.GroundSpeed = &gs
+	v.Track = &track
+}
+
+// decodeAirspeed decodes the subtype 3/4 magnetic heading and airspeed.
+// Heading is reported only when its status bit is set; a zero raw airspeed is
+// the "no data" sentinel.
+func decodeAirspeed(r *RawMessage, v *Velocity) {
+	if r.esbits(14, 14) == 1 { // magnetic heading status
+		hdg := float64(r.esbits(15, 24)) / 1024 * 360
+		v.Heading = &hdg
+	}
+
+	as := r.esbits(26, 35)
+	if as == 0 {
+		return
+	}
+
+	airspeed := (float64(as) - 1) * velScale(v.Subtype)
+	v.Airspeed = &airspeed
+	v.AirspeedType = adsbtype.AST(r.esbits(25, 25))
+}
+
+// decodeVerticalRate decodes the vertical rate common to every subtype. A
+// zero raw magnitude is the "no data" sentinel.
+func decodeVerticalRate(r *RawMessage, v *Velocity) {
+	mag := r.esbits(38, 46)
+	if mag == 0 {
+		return
+	}
+
+	rate := safecast.MustConvert[int](mag-1) * 64
+	if r.esbits(37, 37) == 1 { // 1 = down
+		rate = -rate
+	}
+
+	v.VerticalRate = &rate
+	v.VerticalRateSource = adsbtype.VRS(r.esbits(36, 36))
+}
+
+// decodeGNSSBaroDiff decodes the GNSS-minus-barometric altitude difference
+// (sign bit 49, 7-bit magnitude bits 50-56). A raw magnitude of 0 (all zeros)
+// or 127 (all ones) is the "no data" sentinel.
+func decodeGNSSBaroDiff(r *RawMessage, v *Velocity) {
+	mag := r.esbits(50, 56)
+	if mag == 0 || mag == 127 {
+		return
+	}
+
+	diff := safecast.MustConvert[int](mag-1) * 25
+	if r.esbits(49, 49) == 1 { // 1 = GNSS below baro
+		diff = -diff
+	}
+
+	v.GNSSBaroDiff = &diff
+}

--- a/adsb/velocity_test.go
+++ b/adsb/velocity_test.go
@@ -1,0 +1,369 @@
+// Copyright 2026 Collin Kreklow
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+// BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package adsb_test
+
+import (
+	"encoding/hex"
+	"errors"
+	"math"
+	"testing"
+
+	"kreklow.us/go/go-adsb/adsb"
+	"kreklow.us/go/go-adsb/adsbtype"
+)
+
+// All synthetic vectors below were constructed from explicit BDS 0,9
+// subfield values and cross-checked against pyModeS v3.3.0. The canonical
+// subtype-1 vector is the worked example from Sun, "The 1090MHz Riddle".
+
+// mustVelMsg builds a Message from a hex string, failing on any error.
+func mustVelMsg(t *testing.T, s string) *adsb.Message {
+	t.Helper()
+
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("hex.DecodeString(%q): %v", s, err)
+	}
+
+	m := new(adsb.Message)
+
+	err = m.UnmarshalBinary(b)
+	if err != nil {
+		t.Fatalf("UnmarshalBinary: %v", err)
+	}
+
+	return m
+}
+
+// wantFloat asserts a *float64 is non-nil and within tol of want.
+func wantFloat(t *testing.T, name string, got *float64, want, tol float64) {
+	t.Helper()
+
+	if got == nil {
+		t.Errorf("%s = nil, want ~%g", name, want)
+
+		return
+	}
+
+	if math.Abs(*got-want) > tol {
+		t.Errorf("%s = %g, want ~%g", name, *got, want)
+	}
+}
+
+// wantInt asserts a *int is non-nil and equal to want.
+func wantInt(t *testing.T, name string, got *int, want int) {
+	t.Helper()
+
+	if got == nil {
+		t.Errorf("%s = nil, want %d", name, want)
+
+		return
+	}
+
+	if *got != want {
+		t.Errorf("%s = %d, want %d", name, *got, want)
+	}
+}
+
+// wantNil asserts a pointer field is nil (field carried "no data").
+func wantNil(t *testing.T, name string, isNil bool) {
+	t.Helper()
+
+	if !isNil {
+		t.Errorf("%s: expected nil (no data)", name)
+	}
+}
+
+func TestVelocity(t *testing.T) {
+	t.Run("GroundSpeed", testVelGroundSpeed)
+	t.Run("SupersonicGroundSpeed", testVelSupersonicGS)
+	t.Run("AirspeedIAS", testVelAirspeedIAS)
+	t.Run("SupersonicAirspeedTAS", testVelSupersonicTAS)
+	t.Run("NoData", testVelNoData)
+	t.Run("WestSouthDown", testVelWestSouthDown)
+	t.Run("HeadingUnavailable", testVelHeadingUnavail)
+	t.Run("AirspeedUnavailable", testVelAirspeedUnavail)
+	t.Run("DF18", testVelDF18)
+	t.Run("RejectNonVelocity", testVelRejectNonVelocity)
+	t.Run("RejectShortFrame", testVelRejectShortFrame)
+	t.Run("RejectReservedSubtype0", testVelRejectSubtype0)
+	t.Run("RejectReservedSubtype5", testVelRejectSubtype5)
+}
+
+// Canonical subtype-1 ground-speed vector: GS 159.2 kt, track 182.88 deg
+// (true north), vertical rate -832 ft/min from a GNSS source, GNSS-baro
+// difference +550 ft, NACv 0. Intent change false, IFR capable true.
+func testVelGroundSpeed(t *testing.T) {
+	v, err := mustVelMsg(t, "8D485020994409940838175B284F").Velocity()
+	if err != nil {
+		t.Fatalf("Velocity: %v", err)
+	}
+
+	if v.Subtype != 1 {
+		t.Errorf("Subtype = %d, want 1", v.Subtype)
+	}
+
+	wantFloat(t, "GroundSpeed", v.GroundSpeed, 159.20, 0.05)
+	wantFloat(t, "Track", v.Track, 182.88, 0.01)
+	wantNil(t, "Airspeed", v.Airspeed == nil)
+	wantNil(t, "Heading", v.Heading == nil)
+	wantInt(t, "VerticalRate", v.VerticalRate, -832)
+
+	if v.VerticalRateSource != adsbtype.VRS0 {
+		t.Errorf("VerticalRateSource = %v, want GNSS (VRS0)", v.VerticalRateSource)
+	}
+
+	wantInt(t, "GNSSBaroDiff", v.GNSSBaroDiff, 550)
+
+	if v.NACv != 0 {
+		t.Errorf("NACv = %d, want 0", v.NACv)
+	}
+
+	if v.IntentChange {
+		t.Error("IntentChange = true, want false")
+	}
+
+	if !v.IFRCapability {
+		t.Error("IFRCapability = false, want true")
+	}
+}
+
+// Subtype 2 (supersonic ground speed): east 400 kt, north 300 kt -> GS 500,
+// track 53.13 deg; vertical rate +6400 ft/min barometric; GNSS-baro +2500 ft;
+// NACv 1. Exercises the x4 velocity scaling.
+func testVelSupersonicGS(t *testing.T) {
+	v, err := mustVelMsg(t, "8D4840409A486509919465000000").Velocity()
+	if err != nil {
+		t.Fatalf("Velocity: %v", err)
+	}
+
+	if v.Subtype != 2 {
+		t.Errorf("Subtype = %d, want 2", v.Subtype)
+	}
+
+	wantFloat(t, "GroundSpeed", v.GroundSpeed, 500, 0.05)
+	wantFloat(t, "Track", v.Track, 53.13, 0.01)
+	wantInt(t, "VerticalRate", v.VerticalRate, 6400)
+
+	if v.VerticalRateSource != adsbtype.VRS1 {
+		t.Errorf("VerticalRateSource = %v, want Barometric (VRS1)", v.VerticalRateSource)
+	}
+
+	wantInt(t, "GNSSBaroDiff", v.GNSSBaroDiff, 2500)
+
+	if v.NACv != 1 {
+		t.Errorf("NACv = %d, want 1", v.NACv)
+	}
+}
+
+// Subtype 3 (airspeed): IAS 250 kt, magnetic heading 90 deg, vertical rate
+// -1024 ft/min GNSS, GNSS-baro -1000 ft, NACv 2.
+func testVelAirspeedIAS(t *testing.T) {
+	v, err := mustVelMsg(t, "8D4840409B95001F6844A9000000").Velocity()
+	if err != nil {
+		t.Fatalf("Velocity: %v", err)
+	}
+
+	if v.Subtype != 3 {
+		t.Errorf("Subtype = %d, want 3", v.Subtype)
+	}
+
+	wantNil(t, "GroundSpeed", v.GroundSpeed == nil)
+	wantFloat(t, "Airspeed", v.Airspeed, 250, 0.05)
+
+	if v.AirspeedType != adsbtype.AST0 {
+		t.Errorf("AirspeedType = %v, want IAS (AST0)", v.AirspeedType)
+	}
+
+	wantFloat(t, "Heading", v.Heading, 90, 0.2)
+	wantInt(t, "VerticalRate", v.VerticalRate, -1024)
+	wantInt(t, "GNSSBaroDiff", v.GNSSBaroDiff, -1000)
+
+	if v.NACv != 2 {
+		t.Errorf("NACv = %d, want 2", v.NACv)
+	}
+}
+
+// Subtype 4 (supersonic airspeed): TAS 600 kt, magnetic heading 270 deg,
+// vertical rate and GNSS-baro both "no data". Exercises x4 airspeed scaling
+// and the TAS airspeed type.
+func testVelSupersonicTAS(t *testing.T) {
+	v, err := mustVelMsg(t, "8D4840409C470092F00000000000").Velocity()
+	if err != nil {
+		t.Fatalf("Velocity: %v", err)
+	}
+
+	if v.Subtype != 4 {
+		t.Errorf("Subtype = %d, want 4", v.Subtype)
+	}
+
+	wantFloat(t, "Airspeed", v.Airspeed, 600, 0.05)
+
+	if v.AirspeedType != adsbtype.AST1 {
+		t.Errorf("AirspeedType = %v, want TAS (AST1)", v.AirspeedType)
+	}
+
+	wantFloat(t, "Heading", v.Heading, 270, 0.2)
+	wantNil(t, "VerticalRate", v.VerticalRate == nil)
+	wantNil(t, "GNSSBaroDiff", v.GNSSBaroDiff == nil)
+}
+
+// All velocity, vertical-rate and GNSS-baro fields carry the all-zero
+// "no data" sentinel, but the header fields are populated (subtype 1,
+// IFR capable, NACv 5). The header must decode while every optional pointer
+// stays nil.
+func testVelNoData(t *testing.T) {
+	v, err := mustVelMsg(t, "8D48404099680000000000000000").Velocity()
+	if err != nil {
+		t.Fatalf("Velocity: %v", err)
+	}
+
+	if v.Subtype != 1 {
+		t.Errorf("Subtype = %d, want 1", v.Subtype)
+	}
+
+	if !v.IFRCapability {
+		t.Error("IFRCapability = false, want true")
+	}
+
+	if v.NACv != 5 {
+		t.Errorf("NACv = %d, want 5", v.NACv)
+	}
+
+	wantNil(t, "GroundSpeed", v.GroundSpeed == nil)
+	wantNil(t, "Track", v.Track == nil)
+	wantNil(t, "Airspeed", v.Airspeed == nil)
+	wantNil(t, "Heading", v.Heading == nil)
+	wantNil(t, "VerticalRate", v.VerticalRate == nil)
+	wantNil(t, "GNSSBaroDiff", v.GNSSBaroDiff == nil)
+}
+
+// Subtype 1 with west/south direction bits, a downward vertical rate, and a
+// GNSS-below-baro difference: west 100 kt, south 200 kt -> GS 223.6,
+// track 206.57 deg; VR -1600 ft/min baro; GNSS-baro -500 ft; NACv 3.
+func testVelWestSouthDown(t *testing.T) {
+	v, err := mustVelMsg(t, "8D484040995C6599386895000000").Velocity()
+	if err != nil {
+		t.Fatalf("Velocity: %v", err)
+	}
+
+	wantFloat(t, "GroundSpeed", v.GroundSpeed, 223.61, 0.05)
+	wantFloat(t, "Track", v.Track, 206.57, 0.01)
+	wantInt(t, "VerticalRate", v.VerticalRate, -1600)
+
+	if v.VerticalRateSource != adsbtype.VRS1 {
+		t.Errorf("VerticalRateSource = %v, want Barometric (VRS1)", v.VerticalRateSource)
+	}
+
+	wantInt(t, "GNSSBaroDiff", v.GNSSBaroDiff, -500)
+
+	if v.NACv != 3 {
+		t.Errorf("NACv = %d, want 3", v.NACv)
+	}
+}
+
+// Subtype 3 with the heading-status bit clear (heading unavailable) but a
+// valid airspeed, and a GNSS-baro magnitude of all-ones (127) which also
+// means "no data".
+func testVelHeadingUnavail(t *testing.T) {
+	v, err := mustVelMsg(t, "8D4840409B000016A0007F000000").Velocity()
+	if err != nil {
+		t.Fatalf("Velocity: %v", err)
+	}
+
+	wantFloat(t, "Airspeed", v.Airspeed, 180, 0.05)
+	wantNil(t, "Heading", v.Heading == nil)
+	wantNil(t, "GNSSBaroDiff", v.GNSSBaroDiff == nil)
+}
+
+// Subtype 3 with a valid magnetic heading (45 deg) but an all-zero airspeed
+// field: Heading is set while Airspeed stays nil.
+func testVelAirspeedUnavail(t *testing.T) {
+	v, err := mustVelMsg(t, "8D4840409B048000101000000000").Velocity()
+	if err != nil {
+		t.Fatalf("Velocity: %v", err)
+	}
+
+	wantFloat(t, "Heading", v.Heading, 45, 0.2)
+	wantNil(t, "Airspeed", v.Airspeed == nil)
+}
+
+// A DF18 (TIS-B / non-transponder) extended squitter with CF 0 carries the
+// same BDS 0,9 velocity payload as DF17 and must decode identically:
+// east 120 kt, north 160 kt -> GS 200, track 36.87 deg; VR +64 ft/min GNSS;
+// GNSS-baro +100 ft; NACv 1.
+func testVelDF18(t *testing.T) {
+	v, err := mustVelMsg(t, "9048404099487914200805000000").Velocity()
+	if err != nil {
+		t.Fatalf("Velocity: %v", err)
+	}
+
+	if v.Subtype != 1 {
+		t.Errorf("Subtype = %d, want 1", v.Subtype)
+	}
+
+	wantFloat(t, "GroundSpeed", v.GroundSpeed, 200, 0.05)
+	wantFloat(t, "Track", v.Track, 36.87, 0.01)
+	wantInt(t, "VerticalRate", v.VerticalRate, 64)
+
+	if v.VerticalRateSource != adsbtype.VRS0 {
+		t.Errorf("VerticalRateSource = %v, want GNSS (VRS0)", v.VerticalRateSource)
+	}
+
+	wantInt(t, "GNSSBaroDiff", v.GNSSBaroDiff, 100)
+}
+
+// A DF17 airborne-position message (ES type 11) is not a velocity message.
+func testVelRejectNonVelocity(t *testing.T) {
+	_, err := mustVelMsg(t, "8D40621D58C382D690C8AC2863A7").Velocity()
+	if !errors.Is(err, adsb.ErrNotAvailable) {
+		t.Errorf("err = %v, want ErrNotAvailable", err)
+	}
+}
+
+// A short-frame surveillance message (DF4) has no extended squitter and must
+// be rejected.
+func testVelRejectShortFrame(t *testing.T) {
+	_, err := mustVelMsg(t, "20001910bc45e9").Velocity()
+	if !errors.Is(err, adsb.ErrNotAvailable) {
+		t.Errorf("err = %v, want ErrNotAvailable", err)
+	}
+}
+
+// Type code 19 with reserved subtype 0 is not a defined velocity format and
+// must be rejected.
+func testVelRejectSubtype0(t *testing.T) {
+	_, err := mustVelMsg(t, "8D48404098000100200401000000").Velocity()
+	if !errors.Is(err, adsb.ErrNotAvailable) {
+		t.Errorf("err = %v, want ErrNotAvailable", err)
+	}
+}
+
+// Type code 19 with reserved subtype 5 is not a defined velocity format and
+// must be rejected.
+func testVelRejectSubtype5(t *testing.T) {
+	_, err := mustVelMsg(t, "8D4840409D000100200401000000").Velocity()
+	if !errors.Is(err, adsb.ErrNotAvailable) {
+		t.Errorf("err = %v, want ErrNotAvailable", err)
+	}
+}

--- a/adsbtype/adsbtype_test.go
+++ b/adsbtype/adsbtype_test.go
@@ -46,6 +46,10 @@ func TestConst(t *testing.T) {
 		adsbtype.BDS02: "adsbtype.BDS: Linked Comm-B, segment 2",
 		adsbtype.SSS0:  "adsbtype.SSS: No condition information",
 		adsbtype.TRS0:  "adsbtype.TRS: No capability",
+		adsbtype.VRS0:  "adsbtype.VRS: GNSS",
+		adsbtype.VRS1:  "adsbtype.VRS: Barometric",
+		adsbtype.AST0:  "adsbtype.AST: Indicated airspeed (IAS)",
+		adsbtype.AST1:  "adsbtype.AST: True airspeed (TAS)",
 
 		adsbtype.TYPE0: "adsbtype.TYPE: No position information",
 	} {
@@ -72,6 +76,8 @@ func TestConstUnknown(t *testing.T) {
 		adsbtype.BDS(0x99): "adsbtype.BDS: Unknown value 99",
 		adsbtype.SSS(99):   "adsbtype.SSS: Unknown value 99",
 		adsbtype.TRS(99):   "adsbtype.TRS: Unknown value 99",
+		adsbtype.VRS(99):   "adsbtype.VRS: Unknown value 99",
+		adsbtype.AST(99):   "adsbtype.AST: Unknown value 99",
 
 		adsbtype.TYPE(99): "adsbtype.TYPE: Unknown value 99",
 	} {

--- a/adsbtype/es.go
+++ b/adsbtype/es.go
@@ -95,6 +95,52 @@ func (c TYPE) String() string {
 	return fmt.Sprintf("Unknown value %d", c)
 }
 
+// VRS is the vertical rate source subfield.
+type VRS uint64
+
+// Vertical Rate Source Subfield values.
+const (
+	VRS0 VRS = 0 // GNSS
+	VRS1 VRS = 1 // Barometric
+)
+
+var mVRS = map[VRS]string{
+	VRS0: "GNSS",
+	VRS1: "Barometric",
+}
+
+// String representation of VRS.
+func (c VRS) String() string {
+	if str, ok := mVRS[c]; ok {
+		return str
+	}
+
+	return fmt.Sprintf("Unknown value %d", c)
+}
+
+// AST is the airspeed type subfield.
+type AST uint64
+
+// Airspeed Type Subfield values.
+const (
+	AST0 AST = 0 // Indicated airspeed (IAS)
+	AST1 AST = 1 // True airspeed (TAS)
+)
+
+var mAST = map[AST]string{
+	AST0: "Indicated airspeed (IAS)",
+	AST1: "True airspeed (TAS)",
+}
+
+// String representation of AST.
+func (c AST) String() string {
+	if str, ok := mAST[c]; ok {
+		return str
+	}
+
+	return fmt.Sprintf("Unknown value %d", c)
+}
+
 // AcCat is the extended squitter aircraft emitter category.
 type AcCat string
 


### PR DESCRIPTION
Add Message.Velocity() returning a decoded Velocity struct, mirroring the existing Message.CPR() precedent. Covers the full BDS 0,9 register:

  - ground speed and true-north track (subtypes 1, 2)
  - airspeed and magnetic heading (subtypes 3, 4)
  - supersonic x4 velocity scaling (subtypes 2, 4)
  - vertical rate with barometric/GNSS source
  - GNSS-minus-baro altitude difference
  - intent-change, IFR-capability and NACv metadata

Optional quantities are pointers; a nil pointer denotes the register's "no data" sentinel (all-zero, and additionally all-ones for the 7-bit GNSS-baro magnitude). Decoding works for both DF17 and DF18 via ESType().

Add adsbtype VRS (vertical rate source) and AST (airspeed type) stringer enums for the new typed fields.

Tests are cross-checked against pyModeS v3.3.0 and cover all four subtypes, no-data sentinels, sign handling, DF18, and rejection of non-velocity and reserved-subtype messages.